### PR TITLE
[feture] 이벤트, 그룹 리스트와 수정폼 합치기

### DIFF
--- a/client/src/api/loadGroupList.tsx
+++ b/client/src/api/loadGroupList.tsx
@@ -11,7 +11,6 @@ export const LoadGroupList = () => {
         bandName: group.bandName,
       }));
 
-      console.log(filteredEvent);
       return filteredEvent;
     })
     .catch(error => {

--- a/client/src/components/EventGroupSwitcher/EventCard/EventCard.styles.ts
+++ b/client/src/components/EventGroupSwitcher/EventCard/EventCard.styles.ts
@@ -1,51 +1,51 @@
 import styled from 'styled-components';
 
 export const Card = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 400px;
-  height: 200px;
-  border: 3px solid white;
-  border-radius: 15px;
-  padding: 0px 10px 10px 15px;
+    display: flex;
+    flex-direction: column;
+    width: 350px;
+    height: 180px;
+    border: 3px solid white;
+    border-radius: 15px;
+    padding: 0px 10px 10px 15px;
 
-  &:hover {
-    border: 3px solid #4e54f5;
-  }
-  background-color: white;
+    &:hover {
+        border: 3px solid #4e54f5;
+    }
+    background-color: white;
 `;
 
 export const EventTitle = styled.div`
-  height: 40px;
-  display: flex;
-  justify-content: space-between;
-  img {
-    width: 25px;
-    height: 25px;
-    cursor: pointer;
-    margin-top: 20px;
-  }
+    height: 40px;
+    display: flex;
+    justify-content: space-between;
+    img {
+        width: 25px;
+        height: 25px;
+        cursor: pointer;
+        margin-top: 20px;
+    }
 `;
 
 export const EventTime = styled.div`
-  display: flex;
-  flex-direction: row;
-  h3 {
-    font-size: 15px;
-  }
-  span {
-    color: #4e54f5;
-  }
+    display: flex;
+    flex-direction: row;
+    h3 {
+        font-size: 15px;
+    }
+    span {
+        color: #4e54f5;
+    }
 `;
 
 export const Group = styled.div`
-  display: flex;
-  flex-direction: column;
-  h3 {
-    font-size: 15px;
-    color: lightgray;
-    margin: 0;
-    padding: 0;
-    line-height: 1.2;
-  }
+    display: flex;
+    flex-direction: column;
+    h3 {
+        font-size: 15px;
+        color: lightgray;
+        margin: 0;
+        padding: 0;
+        line-height: 1.2;
+    }
 `;

--- a/client/src/components/EventGroupSwitcher/EventCard/EventCard.tsx
+++ b/client/src/components/EventGroupSwitcher/EventCard/EventCard.tsx
@@ -3,9 +3,12 @@ import * as Styled from 'components/EventGroupSwitcher/EventCard/EventCard.style
 import ParticipateProgress from 'components/EventGroupSwitcher/EventCard/ParticipateProgress/ParticipateProgress';
 import {EventInfo, Band} from 'types/eventTypes';
 import {LoadEventList} from 'api/loadEventList';
+import { useRecoilState } from 'recoil';
+import { selectedEventIdState } from 'recoil/currentEventId';
 
 const EventCard = () => {
-  const [events, setEvents] = useState<EventInfo[]>([]); // State to store event data
+  const [events, setEvents] = useState<EventInfo[]>([]);
+  const [selectedEventId, setSelectedEventId] = useRecoilState(selectedEventIdState);
 
   useEffect(() => {
     LoadEventList().then(filteredEvent => {
@@ -13,45 +16,49 @@ const EventCard = () => {
     });
   }, []);
 
+  const handleCardClick = (eventId: number) => {
+    setSelectedEventId(eventId.toString()); // toString()은 제거예정
+  };
+
   return (
-    <>
-      {events.map((event: EventInfo) => (
-        <Styled.Card key={event.eventId}>
-          <Styled.EventTitle>
-            <h2>{event.eventName}</h2>
-            <img src="/images/EditEvent.png" alt="EditEvenIcon" />
-          </Styled.EventTitle>
-          <Styled.EventTime>
-            <h3>
-              {event.startAt} &nbsp;&nbsp;<span>{'>'}</span>&nbsp;&nbsp;
-            </h3>
-            <h3>{event.endAt}</h3>
-          </Styled.EventTime>
-          <Styled.Group>
-            {event.bands.length >= 3 ? (
-              <>
-                {event.bands.slice(0, 3).map((band: Band) => (
-                  <h3 key={band.bandId}>{band.bandName}</h3>
-                ))}
-                <h3>외 {event.bands.length - 3}개</h3>
-              </>
-            ) : (
-              <>
-                {event.bands.map((band: Band) => (
-                  <h3 key={band.bandId}>{band.bandName}</h3>
-                ))}
-                {Array(3 - event.bands.length)
-                  .fill(null)
-                  .map((_, idx: number) => (
-                    <h3 key={`empty-${idx}`}>&nbsp;</h3>
-                  ))}
-              </>
-            )}
-          </Styled.Group>
-          <ParticipateProgress />
-        </Styled.Card>
-      ))}
-    </>
+      <>
+        {events.map((event: EventInfo) => (
+            <Styled.Card key={event.eventId} onClick={() => handleCardClick(event.eventId)}>
+              <Styled.EventTitle>
+                <h2>{event.eventName}</h2>
+                <img src="/images/EditEvent.png" alt="EditEvenIcon" />
+              </Styled.EventTitle>
+              <Styled.EventTime>
+                <h3>
+                  {event.startAt} &nbsp;&nbsp;<span>{'>'}</span>&nbsp;&nbsp;
+                </h3>
+                <h3>{event.endAt}</h3>
+              </Styled.EventTime>
+              <Styled.Group>
+                {event.bands.length >= 3 ? (
+                    <>
+                      {event.bands.slice(0, 3).map((band: Band) => (
+                          <h3 key={band.bandId}>{band.bandName}</h3>
+                      ))}
+                      <h3>외 {event.bands.length - 3}개</h3>
+                    </>
+                ) : (
+                    <>
+                      {event.bands.map((band: Band) => (
+                          <h3 key={band.bandId}>{band.bandName}</h3>
+                      ))}
+                      {Array(3 - event.bands.length)
+                          .fill(null)
+                          .map((_, idx: number) => (
+                              <h3 key={`empty-${idx}`}>&nbsp;</h3>
+                          ))}
+                    </>
+                )}
+              </Styled.Group>
+              <ParticipateProgress />
+            </Styled.Card>
+        ))}
+      </>
   );
 };
 

--- a/client/src/components/EventGroupSwitcher/EventCard/ParticipateProgress/ParticipateProgress.styles.ts
+++ b/client/src/components/EventGroupSwitcher/EventCard/ParticipateProgress/ParticipateProgress.styles.ts
@@ -1,29 +1,28 @@
 import styled from 'styled-components';
 
 export const ParticipateProgressBox = styled.div`
-  display: flex;
-  flex-direction: column;
+    display: flex;
+    flex-direction: column;
 `;
 
 export const ParticipateNum = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-  margin-top: 10px;
-  h3 {
-    font-size: 15px;
-    line-height: 0.1;
-  }
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    h3 {
+        font-size: 15px;
+        line-height: 0.1;
+    }
 `;
 
 export const Progress = styled.div`
-  width: 400px;
-  height: 10px;
-  background-color: #4e54f5;
-  border-radius: 5px;
+    width: 350px;
+    height: 5px;
+    background-color: #4e54f5;
+    border-radius: 5px;
 `;
 
 export const Gauge = styled.div`
-  // 여기에 props로 참여자 수 받아서 backgroud-color 조정하는 코드 추가 예정
+    // 여기에 props로 참여자 수 받아서 backgroud-color 조정하는 코드 추가 예정
 `;

--- a/client/src/components/EventGroupSwitcher/EventCardList/EventCardList.styles.ts
+++ b/client/src/components/EventGroupSwitcher/EventCardList/EventCardList.styles.ts
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
 
 export const EventListGrid = styled.div`
-  display: grid;
-  grid-template-columns: 430px 430px;
-  gap: 15px;
-  background-color: #ccc;
-  @media (max-width: 768px) {
-    grid-template-columns: 1fr;
-  }
+    display: grid;
+    height: 100%;
+    grid-template-columns: 380px 380px;
+    gap: 24px;
+    @media (max-width: 768px) {
+        grid-template-columns: 1fr;
+    }
+   margin: 20px 16px;
 `;

--- a/client/src/components/EventGroupSwitcher/EventGroup/GroupCard.styles.ts
+++ b/client/src/components/EventGroupSwitcher/EventGroup/GroupCard.styles.ts
@@ -3,12 +3,11 @@ import styled from 'styled-components';
 export const GroupCard = styled.div`
   display: flex;
   flex-direction: column;
-  width: 250px;
-  height: 100px;
+  width: 213px;
+  height: 77px;
   border: 3px solid white;
   border-radius: 15px;
   padding: 0px 10px 10px 15px;
-
   &:hover {
     border: 3px solid #4e54f5;
   }
@@ -16,10 +15,11 @@ export const GroupCard = styled.div`
 `;
 
 export const GroupTitle = styled.div`
-  height: 20px;
   display: flex;
   justify-content: space-between;
-  font-size: 20px;
+  width: 113px;
+  height: 17px;
+  font-size: 13px;
   img {
     width: 25px;
     height: 25px;

--- a/client/src/components/EventGroupSwitcher/EventGroup/GroupCard.tsx
+++ b/client/src/components/EventGroupSwitcher/EventGroup/GroupCard.tsx
@@ -2,9 +2,13 @@ import React, {useEffect, useState} from 'react';
 import {LoadGroupList} from 'api/loadGroupList';
 import {Band} from 'types/eventTypes';
 import * as Styled from 'components/EventGroupSwitcher/EventGroup/GroupCard.styles';
+import {useRecoilState} from 'recoil';
+import {selectedBandIdState} from 'recoil/currentBandId';
 
 const GroupCard = () => {
   const [groups, setGroupList] = useState<Band[]>([]); // State to store event data
+  const [selectedBandId, setSelectedBandId] =
+    useRecoilState(selectedBandIdState);
 
   useEffect(() => {
     LoadGroupList().then(filteredEvent => {
@@ -12,10 +16,14 @@ const GroupCard = () => {
     });
   }, []);
 
+  const handleCardClick = (bandId: number) => {
+    setSelectedBandId(bandId);
+  };
+
   return (
     <>
       {groups.map((group: Band) => (
-        <Styled.GroupCard>
+        <Styled.GroupCard onClick={() => handleCardClick(group.bandId)}>
           <Styled.GroupTitle>
             <h2>{group.bandName}</h2>
           </Styled.GroupTitle>

--- a/client/src/components/EventGroupSwitcher/EventGroupList/EventGroupList.styles.ts
+++ b/client/src/components/EventGroupSwitcher/EventGroupList/EventGroupList.styles.ts
@@ -2,8 +2,10 @@ import styled from 'styled-components';
 
 export const GroupListGrid = styled.div`
   display: grid;
-  grid-template-columns: 289px 289px 289px;
-  gap: 15px;
+  grid-template-columns: 249px 249px 249px;
+  height: 100%;
+  gap: 24px;
+  margin: 20px 16px;
   background-color: #ccc;
   @media (max-width: 768px) {
     grid-template-columns: 2fr;

--- a/client/src/components/common/CommonFormLayout/CommonFormLayout.styles.ts
+++ b/client/src/components/common/CommonFormLayout/CommonFormLayout.styles.ts
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 export const FormContainer = styled.div`
   background-color: #ffffff;
   position: relative;
-  max-width: 350px;
-  margin: 0 auto;
+    width: 20%;
+  margin: 20px 16px;
   padding: 50px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   border-radius: 10px;

--- a/client/src/pages/EventGroupSwitcher/EventGroupSwitcher.styles.ts
+++ b/client/src/pages/EventGroupSwitcher/EventGroupSwitcher.styles.ts
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+export const EventGroupWrapper = styled.div`
+    display: flex;
+    flex-direction: row;
+`
+
+export const DivideLine = styled.hr`
+    margin : 0;
+    border: 1px solid #C1C7CD;
+`

--- a/client/src/pages/EventGroupSwitcher/EventGroupSwitcher.tsx
+++ b/client/src/pages/EventGroupSwitcher/EventGroupSwitcher.tsx
@@ -1,15 +1,30 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import CreateEventForm from 'components/EventGroupSwitcher/CreateEventForm/CreateEventForm';
 import Header from 'components/common/Header/Header';
+import EventCardList from 'components/EventGroupSwitcher/EventCardList/EventCardList';
+import EventGroupList from 'components/EventGroupSwitcher/EventGroupList/EventGroupList';
+import CreateGroupForm from 'components/EventGroupSwitcher/CreateGroupForm/CreateGroupForm';
+import * as Styled from 'pages/EventGroupSwitcher/EventGroupSwitcher.styles';
+import {useRecoilValue} from 'recoil';
+import {selectedEventIdState} from 'recoil/currentEventId';
 
 const EventGroupSwitcher = () => {
-  // Todo
-  // 이벤트 리스트, 그룹 리스트를 클릭 이벤트에 따라 띄워줘야 한다.
+  const selectedEventId = useRecoilValue(selectedEventIdState);
+  const selectedBandId = useRecoilValue(selectedEventIdState);
+
+  useEffect(() => {}, [selectedEventId]);
 
   return (
     <>
       <Header />
-      <CreateEventForm />
+      <Styled.EventGroupWrapper>
+        <EventCardList />
+        <Styled.DivideLine />
+        {selectedEventId && <CreateEventForm eventId={selectedEventId} />}
+        {/*  <EventGroupList/>*/}
+        {/*  <Styled.DivideLine/>*/}
+        {/*  {selectedBandIdState && <CreateGroupForm bandId={selectedBandId} />}*/}
+      </Styled.EventGroupWrapper>
     </>
   );
 };

--- a/client/src/recoil/currentBandId.ts
+++ b/client/src/recoil/currentBandId.ts
@@ -1,0 +1,6 @@
+import {atom} from 'recoil';
+
+export const selectedBandIdState = atom<number | null>({
+  key: 'selectedBandIdState',
+  default: null,
+});

--- a/client/src/recoil/currentEventId.ts
+++ b/client/src/recoil/currentEventId.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const selectedEventIdState = atom<string | null>({
+    key: 'selectedEventIdState',
+    default: null,
+});


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [ ] 버그 수정 🐛
- [ ] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

### 변경 사항

### 🔫 컴포넌트 합치기 
<img width="500" alt="스크린샷 2024-09-21 20 20 54" src="https://github.com/user-attachments/assets/9671264f-e8e7-4d13-9c29-fda58e304ed7"><br/>
- 이벤트 카드리스트와 이벤트 수정폼을 하나의 박스로 합쳤습니다
- 아래는 두 컴포넌트를 묶는 <code>Wrpper</code>와 나눔선인 <code>DivedeLine</code>을 스타일 컴포넌트로 제작한 코드입니다.
```typescript
import styled from "styled-components";

export const EventGroupWrapper = styled.div`
    display: flex;
    flex-direction: row;
`

export const DivideLine = styled.hr`
    margin : 0;
    border: 1px solid #C1C7CD;
`
```
<img width="500" alt="스크린샷 2024-09-21 20 26 59" src="https://github.com/user-attachments/assets/f7ec58a8-ff92-44ad-8da9-4f9f5444da99"><br/>
- 그룹 카드리스트와 그룹 수정폼을 하나의 박스로 합쳤습니다

### 🔫 Recoil로 prop 저장

- 이벤트나 그룹 카드를 선택할 시 각각 해당하는 이벤트, 그룹 수정폼이 뜨도록 해야하는데 외부로 prop을 전달하기에 어려움이 있다고 판단했습니다.
- 전역으로 상태를 저장하는 Recoil을 사용하여 <code>eventId</code>와 <code>bandId</code>를 **클릭 시에만** 저장되도록 하였습니다.

### 리코일 파일 세팅
```typescript
import { atom } from 'recoil';

// eventId를 저장
export const selectedEventIdState = atom<string | null>({
    key: 'selectedEventIdState',
    default: null,
});

// bandId를 저장
export const selectedBandIdState = atom<number | null>({
  key: 'selectedBandIdState',
  default: null,
});
```

### 카드 클릭 시 리코일에 저장
```typescript
import { useRecoilState } from 'recoil';
import { selectedEventIdState } from 'recoil/currentEventId';

const [selectedEventId, setSelectedEventId] = useRecoilState(selectedEventIdState);

const handleCardClick = (eventId: number) => {
    setSelectedEventId(eventId.toString()); // toString()은 제거예정
  };

 <Styled.Card key={event.eventId} onClick={() => handleCardClick(event.eventId)}>
...
```

### id 가져와서 렌더링
```typescript

const EventGroupSwitcher = () => {
  const selectedEventId = useRecoilValue(selectedEventIdState);
  const selectedBandId = useRecoilValue(selectedEventIdState);

  useEffect(() => {}, [selectedEventId]);

  return (
    <>
      <Header />
      <Styled.EventGroupWrapper>
        <EventCardList />
        <Styled.DivideLine />
        {selectedEventId && <CreateEventForm eventId={selectedEventId} />}
        {/*  <EventGroupList/>*/}
        {/*  <Styled.DivideLine/>*/}
        {/*  {selectedBandIdState && <CreateGroupForm bandId={selectedBandId} />}*/}
      </Styled.EventGroupWrapper>
    </>
  );
};

export default EventGroupSwitcher;
```
- prop이 리코일에 있는지 확인한 다음, 있는 경우에만 수정폼을 렌더링합니다.

### 이슈 사항
1. 프로그레바 구현을 완성할 예정입니다.
2. 그룹 인원을 가져와서 보여줄 예정입니다.
3. 아래 그림처럼 이벤트 / 그룹 버튼을 클릭했을 때 각각 다른 컴포넌트가 뜨도록 할 예정입니다.

### To reviewer
```
[PN]을 활용해서 리뷰를 남겨주세요!
P1: 꼭 반영해 주세요 (Request changes)
P2: 웬만하면 반영해 주세요 (Comment)
P3: 그냥 사소한 의견입니다 (Approve)
```
ex) [P3]여기에서 이 부분 잘 모르겠는데 한번 봐주실 수 있나요?


