### PR TITLE
[hotfix] Band 타입 임포트 및 eventId 타입 수정

### DIFF
--- a/client/src/api/loadGroupList.tsx
+++ b/client/src/api/loadGroupList.tsx
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import {Band} from 'types/eventTypes';
+import {Band} from 'types/groupTypes';
 
 export const LoadGroupList = () => {
   return axios

--- a/client/src/components/EventGroupSwitcher/EventCard/EventCard.tsx
+++ b/client/src/components/EventGroupSwitcher/EventCard/EventCard.tsx
@@ -1,7 +1,8 @@
 import React, {useEffect, useState} from 'react';
 import * as Styled from 'components/EventGroupSwitcher/EventCard/EventCard.styles';
 import ParticipateProgress from 'components/EventGroupSwitcher/EventCard/ParticipateProgress/ParticipateProgress';
-import {EventInfo, Band} from 'types/eventTypes';
+import {EventInfo} from 'types/eventTypes';
+import {Band} from 'types/groupTypes';
 import {LoadEventList} from 'api/loadEventList';
 import { useRecoilState } from 'recoil';
 import { selectedEventIdState } from 'recoil/currentEventId';
@@ -17,7 +18,7 @@ const EventCard = () => {
   }, []);
 
   const handleCardClick = (eventId: number) => {
-    setSelectedEventId(eventId.toString()); // toString()은 제거예정
+    setSelectedEventId(eventId); // toString()은 제거예정
   };
 
   return (

--- a/client/src/components/EventGroupSwitcher/EventGroup/GroupCard.tsx
+++ b/client/src/components/EventGroupSwitcher/EventGroup/GroupCard.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {LoadGroupList} from 'api/loadGroupList';
-import {Band} from 'types/eventTypes';
+import {Band} from 'types/groupTypes';
 import * as Styled from 'components/EventGroupSwitcher/EventGroup/GroupCard.styles';
 import {useRecoilState} from 'recoil';
 import {selectedBandIdState} from 'recoil/currentBandId';

--- a/client/src/recoil/currentEventId.ts
+++ b/client/src/recoil/currentEventId.ts
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
 
-export const selectedEventIdState = atom<string | null>({
+export const selectedEventIdState = atom<number | null>({
     key: 'selectedEventIdState',
     default: null,
 });


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [x] 버그 수정 🐛
- [ ] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

### 변경 사항

### band 타입 임포트 수정

- 기존
``` typescript
import {Band} from 'types/eventTypes';
```

- 수정
``` typescript
import {Band} from 'types/groupTypes';
```

### eventId 타입 변경

- string 에서 number로 변경
```typescript
import { atom } from 'recoil';

export const selectedEventIdState = atom<number | null>({
    key: 'selectedEventIdState',
    default: null,
});
```
### 이슈 사항
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

### To reviewer
```
[PN]을 활용해서 리뷰를 남겨주세요!
P1: 꼭 반영해 주세요 (Request changes)
P2: 웬만하면 반영해 주세요 (Comment)
P3: 그냥 사소한 의견입니다 (Approve)
```
ex) [P3]여기에서 이 부분 잘 모르겠는데 한번 봐주실 수 있나요?


