### PR TITLE
[feature] 이벤트 및 그룹 카드 선택 시 border 유지

### DIFF
--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PrettierConfiguration">
+    <option name="myConfigurationMode" value="AUTOMATIC" />
+    <option name="myRunOnSave" value="true" />
+    <option name="myRunOnReformat" value="true" />
+  </component>
+</project>

--- a/client/src/components/EventGroupSwitcher/EventCard/EventCard.styles.ts
+++ b/client/src/components/EventGroupSwitcher/EventCard/EventCard.styles.ts
@@ -1,19 +1,24 @@
 import styled from 'styled-components';
 
 export const Card = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 350px;
-  height: 180px;
-  border: 3px solid white;
-  border-radius: 15px;
-  padding: 0px 10px 10px 15px;
+    display: flex;
+    flex-direction: column;
+    width: 350px;
+    height: 180px;
+    border: 3px solid white;
+    border-radius: 15px;
+    padding: 0px 10px 10px 15px;
+    background-color: white;
 
-  &:hover {
-    border: 3px solid #4e54f5;
-  }
-  background-color: white;
+    &:hover {
+        border: 3px solid #4e54f5;
+    }
+
+    &.selected {
+        border: 3px solid #4e54f5;
+    }
 `;
+
 
 export const EventTitle = styled.div`
   height: 40px;

--- a/client/src/components/EventGroupSwitcher/EventCard/EventCard.tsx
+++ b/client/src/components/EventGroupSwitcher/EventCard/EventCard.tsx
@@ -27,12 +27,15 @@ const EventCard = () => {
       {events.map((event: CheckInInfo) => (
         <Styled.Card
           key={event.eventId}
-          onClick={() => handleCardClick(event.eventId)}
           className={selectedEventId === event.eventId ? 'selected' : ''}
         >
           <Styled.EventTitle>
             <h2>{event.eventName}</h2>
-            <img src="/images/EditEvent.png" alt="EditEvenIcon" />
+            <img
+              onClick={() => handleCardClick(event.eventId)}
+              src="/images/EditEvent.png"
+              alt="EditEvenIcon"
+            />
           </Styled.EventTitle>
           <Styled.EventTime>
             <h3>

--- a/client/src/components/EventGroupSwitcher/EventCard/EventCard.tsx
+++ b/client/src/components/EventGroupSwitcher/EventCard/EventCard.tsx
@@ -28,6 +28,7 @@ const EventCard = () => {
         <Styled.Card
           key={event.eventId}
           onClick={() => handleCardClick(event.eventId)}
+          className={selectedEventId === event.eventId ? 'selected' : ''}
         >
           <Styled.EventTitle>
             <h2>{event.eventName}</h2>

--- a/client/src/components/EventGroupSwitcher/GroupCard/GroupCard.styles.ts
+++ b/client/src/components/EventGroupSwitcher/GroupCard/GroupCard.styles.ts
@@ -8,10 +8,13 @@ export const GroupCard = styled.div`
   border: 3px solid white;
   border-radius: 15px;
   padding: 0px 10px 10px 15px;
+  background-color: white;
   &:hover {
     border: 3px solid #4e54f5;
   }
-  background-color: white;
+  &.selected {
+    border: 3px solid #4e54f5;
+  }
 `;
 
 export const GroupTitle = styled.div`

--- a/client/src/components/EventGroupSwitcher/GroupCard/GroupCard.tsx
+++ b/client/src/components/EventGroupSwitcher/GroupCard/GroupCard.tsx
@@ -24,12 +24,15 @@ const GroupCard = () => {
     <>
       {groups.map((group: Band) => (
         <Styled.GroupCard
-          onClick={() => handleCardClick(group.bandId)}
           className={selectedBandId === group.bandId ? 'selected' : ''}
         >
           <Styled.GroupTitle>
             <h2>{group.bandName}</h2>
-            <img src="/images/EditEvent.png" alt="EditEvenIcon" />
+            <img
+              onClick={() => handleCardClick(group.bandId)}
+              src="/images/EditEvent.png"
+              alt="EditEvenIcon"
+            />
           </Styled.GroupTitle>
           <h3>50명</h3>
         </Styled.GroupCard>

--- a/client/src/components/EventGroupSwitcher/GroupCard/GroupCard.tsx
+++ b/client/src/components/EventGroupSwitcher/GroupCard/GroupCard.tsx
@@ -23,7 +23,10 @@ const GroupCard = () => {
   return (
     <>
       {groups.map((group: Band) => (
-        <Styled.GroupCard onClick={() => handleCardClick(group.bandId)}>
+        <Styled.GroupCard
+          onClick={() => handleCardClick(group.bandId)}
+          className={selectedBandId === group.bandId ? 'selected' : ''}
+        >
           <Styled.GroupTitle>
             <h2>{group.bandName}</h2>
             <img src="/images/EditEvent.png" alt="EditEvenIcon" />


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [ ] 버그 수정 🐛
- [ ] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

## 변경 사항

### 🌱이벤트카드 및 그룹 카드 className설정

- ✔️className으로 클릭한 카드를 전달하기 위해 

```typescript
//이벤트카드
   <Styled.Card
          key={event.eventId}
          onClick={() => handleCardClick(event.eventId)}
          className={selectedEventId === event.eventId ? 'selected' : ''}
        >

//그룹카드
<Styled.GroupCard
          onClick={() => handleCardClick(group.bandId)}
          className={selectedBandId === group.bandId ? 'selected' : ''}
        >
```

### 스타일 컴포넌트

```typescript
 &.selected {
    border: 3px solid #4e54f5;
  }
```
### 🌱클릭이벤트 변경

- ✔️ 카드 클릭시 -> 이미지 클릭시 수정폼 보이도록 변경

```typescript
//이벤트 카드
 <img
              onClick={() => handleCardClick(group.bandId)}
              src="/images/EditEvent.png"
              alt="EditEvenIcon"
            />
//그룹카드
 <img
              onClick={() => handleCardClick(group.bandId)}
              src="/images/EditEvent.png"
              alt="EditEvenIcon"
            />
```

## 이슈 사항

### To reviewer
```
[PN]을 활용해서 리뷰를 남겨주세요!
P1: 꼭 반영해 주세요 (Request changes)
P2: 웬만하면 반영해 주세요 (Comment)
P3: 그냥 사소한 의견입니다 (Approve)
```
ex) [P3]여기에서 이 부분 잘 모르겠는데 한번 봐주실 수 있나요?


