### PR TITLE
[feature] QR 체크인 화면에 이벤트 데이터 props 로 넘기기

### DIFF
--- a/client/src/components/QrCheckIn/QrScan.tsx
+++ b/client/src/components/QrCheckIn/QrScan.tsx
@@ -32,19 +32,18 @@ const QrScan = ({onScanResult, eventId}: QrScanProps) => {
       const ScannedQrArray = data.text;
       const studentIdStartPoint = 8;
       const studentIdEndPoint = 17;
-      const ExtractedStudentId = ScannedQrArray.substring(
+      Student.studentId = ScannedQrArray.substring(
         studentIdStartPoint,
         studentIdEndPoint,
       );
-      Student.studentId = ExtractedStudentId;
       Student.eventId = parseInt(eventId, 10);
 
       sendToServer(Student)
         .then(res => {
           if (res.data.message === 'OK') {
             onScanResult('정상적으로 참석되었습니다.', '#4E54F5', '#4E54F5');
+            setQrScanned(true);
           }
-          setQrScanned(true);
         })
         .catch(error => {
           // 임시로 에러코드 활용하여 동작
@@ -54,6 +53,7 @@ const QrScan = ({onScanResult, eventId}: QrScanProps) => {
           } else {
             onScanResult('이벤트 해당그룹이 아닙니다.', '#FF7078', '#FF7078');
           }
+          setQrScanned(true);
         });
 
       setTimeout(() => {
@@ -64,7 +64,7 @@ const QrScan = ({onScanResult, eventId}: QrScanProps) => {
           'lightgray',
         );
         setNextScanned(prevKey => prevKey + 1);
-      }, 1000);
+      }, 1500);
     }
   };
 

--- a/client/src/components/QrCheckIn/QrScan.tsx
+++ b/client/src/components/QrCheckIn/QrScan.tsx
@@ -41,21 +41,19 @@ const QrScan = ({onScanResult, eventId}: QrScanProps) => {
 
       sendToServer(Student)
         .then(res => {
-          if (
-            !res.data.message
-          ) {
+          if (res.data.message === 'OK') {
             onScanResult('정상적으로 참석되었습니다.', '#4E54F5', '#4E54F5');
-          } else if (
-              res.data.message === '이미 체크인 했습니다.'
-          ) {
-            onScanResult('이미 참석되었습니다.','#F5C400','#F5C400');
-          } else {
-            onScanResult('이벤트 해당그룹이 아닙니다.', '#FF7078', '#FF7078');
           }
           setQrScanned(true);
         })
         .catch(error => {
-          console.log(error);
+          // 임시로 에러코드 활용하여 동작
+          // 추후 백엔드 코드로 동작 예정
+          if (error.response.status === 500) {
+            onScanResult('이미 참석되었습니다.', '#F5C400', '#F5C400');
+          } else {
+            onScanResult('이벤트 해당그룹이 아닙니다.', '#FF7078', '#FF7078');
+          }
         });
 
       setTimeout(() => {
@@ -71,19 +69,19 @@ const QrScan = ({onScanResult, eventId}: QrScanProps) => {
   };
 
   return (
-      <div>
-        <Styled.QrCameraReveral>
-          <Styled.QrScannerContainer>
-            <Styled.StyledQrScanner>
-              <QrScanner
-                  key={nextScanned}
-                  onScan={handleScan}
-                  onError={handleError}
-              />
-            </Styled.StyledQrScanner>
-          </Styled.QrScannerContainer>
-        </Styled.QrCameraReveral>
-      </div>
+    <div>
+      <Styled.QrCameraReveral>
+        <Styled.QrScannerContainer>
+          <Styled.StyledQrScanner>
+            <QrScanner
+              key={nextScanned}
+              onScan={handleScan}
+              onError={handleError}
+            />
+          </Styled.StyledQrScanner>
+        </Styled.QrScannerContainer>
+      </Styled.QrCameraReveral>
+    </div>
   );
 };
 

--- a/client/src/components/QrCheckIn/qrCode.styles.ts
+++ b/client/src/components/QrCheckIn/qrCode.styles.ts
@@ -1,22 +1,22 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 import QrScanner from 'react-qr-scanner';
 
 export const QrCameraReveral = styled.div`
-    width: 100%;
-    height: 100%;
-    transform: scaleX(-1);
-`
+  width: 100%;
+  height: 100%;
+  transform: scaleX(-1);
+`;
 export const QrScannerContainer = styled.div`
-  width: 580px;
+  width: 400px;
   height: 400px;
-    
+
   @media (max-width: 700px) {
     width: 100%;
     height: 100%;
   }
-`
+`;
 export const StyledQrScanner = styled(QrScanner)`
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;

--- a/client/src/components/event_detail/CheckInTable/CheckInTable.tsx
+++ b/client/src/components/event_detail/CheckInTable/CheckInTable.tsx
@@ -49,7 +49,7 @@ const CheckInTable: React.FC<CheckInTableProps> = ({eventId, filterText}) => {
                 row =>
                   (row.id && row.id.includes(filterText)) || // row.id가 undefined가 아닌지 확인
                   (row.name && row.name.includes(filterText)) || // row.name이 undefined가 아닌지 확인
-                  (row.band && row.band.includes(filterText)), // row.group이 undefined가 아닌지 확인
+                  (row.bandName && row.bandName.includes(filterText)), // row.group이 undefined가 아닌지 확인
               )
               .map(row => (
                 <tr key={row.id}>
@@ -63,7 +63,7 @@ const CheckInTable: React.FC<CheckInTableProps> = ({eventId, filterText}) => {
                       <Styled.CheckInTime>{row.checkInTime}</Styled.CheckInTime>
                     </Styled.CheckInData>
                   </Styled.ThBorder>
-                  <Styled.ThBorder>{row.band}</Styled.ThBorder>
+                  <Styled.ThBorder>{row.bandName}</Styled.ThBorder>
                 </tr>
               ))
           ) : (

--- a/client/src/hooks/useCheckInStudent.tsx
+++ b/client/src/hooks/useCheckInStudent.tsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 interface CheckInStudent {
   id: string;
   name: string;
-  band: string;
+  bandName: string;
   eventStudentStatus: string;
   checkInTime: string;
 }
@@ -21,7 +21,7 @@ const useCheckInStudent = (eventId: string) => {
           (student: CheckInStudent) => ({
             id: student.id,
             name: student.name,
-            group: student.band,
+            bandName: student.bandName,
             eventStudentStatus: student.eventStudentStatus,
             checkInTime:
               student.checkInTime !== null

--- a/client/src/pages/EventDetail/EventDetail.tsx
+++ b/client/src/pages/EventDetail/EventDetail.tsx
@@ -19,20 +19,34 @@ const EventDetail = () => {
 
   const [listFilterText, setListFilterText] = useState<string>('');
   const [title, setTitle] = useState<string>('');
-
   const [groups, setGroups] = useState<Band[]>([]);
+  const [startAt, setStartAt] = useState<string>('');
+  const [endAt, setEndAt] = useState<string>('');
+
   useEffect(() => {
     if (eventId !== 'No Event ID') {
       const eventIdNumber = parseInt(eventId, 10);
       getEventById(eventIdNumber, adminId).then(response => {
         setGroups(response.data.bands);
         setTitle(response.data.eventName);
+        const startAtOriginalData = response.data.startAt;
+        const endAtOriginalData = response.data.endAt;
+        setStartAt(
+          startAtOriginalData.slice(0, 10).replaceAll('-', '.') +
+            ' ' +
+            startAtOriginalData.slice(11, 16).replaceAll('-', '.'),
+        );
+        setEndAt(
+          endAtOriginalData.slice(0, 10).replaceAll('-', '.') +
+            ' ' +
+            endAtOriginalData.slice(11, 16).replaceAll('-', '.'),
+        );
       });
     }
   }, []);
 
   const navigateToQrScanner = () => {
-    navigate('/qrScan', {state: {eventId}});
+    navigate('/qrScan', {state: {eventId, title, startAt, endAt}});
   };
 
   return (

--- a/client/src/pages/QrCheckIn/MainQrCheckIn.styles.ts
+++ b/client/src/pages/QrCheckIn/MainQrCheckIn.styles.ts
@@ -1,101 +1,108 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
 export const Text = styled.div`
-    font-family: Noto Sans;
-    text-align: left;
+  font-family: Noto Sans;
+  text-align: left;
 `;
 
 export const Wrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    min-height: 100vh;
-    padding:0;
-    margin:0;
-    background-color: #F0F4F7;
+  display: flex;
+  flex-direction: column;
+  max-width: 100%;
+  min-height: 100vh;
+  padding: 0;
+  margin: 0 auto;
+  background-color: #f0f4f7;
+`;
+
+export const InnerLayout = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+
+  margin: 0 auto;
 `;
 
 export const Event = styled.div`
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    margin: 30px 20px 40px 20px;
-    padding: 30px 43px 60px 40px;
-    border-radius: 10px;
-    line-height: 27.24px;
-    gap:10px;
-`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  margin: 30px 100px 40px 100px;
+  padding: 30px 40px 60px 40px;
+  border-radius: 10px;
+`;
 
 export const EventContent = styled.div`
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    width: 200px;
-    height:400px;
-    padding:40px;
-    border-radius: 10px;
-    box-shadow: 5px 5px 10px lightgray;
-    background-color: white;
-`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 200px;
+  height: 400px;
+  padding: 40px;
+  border-radius: 10px;
+  box-shadow: 5px 5px 10px lightgray;
+  background-color: white;
+`;
 
 export const EventName = styled(Text)`
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    font-size: 35px;
-    background-color: white;
-    line-height: 80px;
-`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  font-size: 35px;
+  background-color: white;
+  line-height: 80px;
+`;
 
-export const Line = styled("div")`
-    height:1px;
-    background-color:#F0F4F7;
-    border:0;
-`
+export const Line = styled('div')`
+  height: 1px;
+  background-color: #f0f4f7;
+  border: 0;
+`;
 
 export const EventTime = styled(Text)`
-    display: flex;
-    flex-direction: column;
-    font-size: 20px;
-`
+  display: flex;
+  flex-direction: row;
+  font-size: 20px;
+`;
 
 export const GroupBox = styled(Text)`
-    text-align:center;
-    font-size: 20px;
-    color: #697077;
-`
+  text-align: center;
+  font-size: 20px;
+  color: #697077;
+`;
 
 export const Qr = styled.div`
-    width: 100%;
-    max-width:1050px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    margin-left:100px;
-    margin-right:100px;
-    padding:20px;
-    border-radius:10px;
-    background-color: white;
-`
+  width: 100%;
+  max-width: 1050px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-left: 100px;
+  margin-right: 100px;
+  padding: 20px;
+  border-radius: 10px;
+  background-color: white;
+`;
 
-export const QrBox = styled.div<{ qrColor: string }>`
-    margin-top:10px;
-    margin-right:20px;
-    background-color: ${({ qrColor }) => qrColor};
-    border: 25px solid ${({ qrColor }) => qrColor};
-    border-bottom: 20px solid ${({ qrColor }) => qrColor};
-    border-radius: 20px;
-`
+export const QrBox = styled.div<{qrColor: string}>`
+  margin-top: 10px;
+  background-color: ${({qrColor}) => qrColor};
+  border: 25px solid ${({qrColor}) => qrColor};
+  border-bottom: 20px solid ${({qrColor}) => qrColor};
+  border-radius: 20px;
+`;
 
-export const QrMessage = styled(Text)<{ messageColor: string }>`
-    color: ${({ messageColor }) => messageColor};
-    font-size: 32px;
-    font-weight: 400;
-    line-height: 43.58px;
-    margin-top: 25px;
-    margin-bottom: 25px;
-    text-align:center;
-`
+export const QrMessage = styled(Text)<{messageColor: string}>`
+  color: ${({messageColor}) => messageColor};
+  font-size: 32px;
+  font-weight: 400;
+  line-height: 43.58px;
+  margin-top: 25px;
+  margin-bottom: 25px;
+  text-align: center;
+`;

--- a/client/src/pages/QrCheckIn/MainQrCheckIn.styles.ts
+++ b/client/src/pages/QrCheckIn/MainQrCheckIn.styles.ts
@@ -29,7 +29,8 @@ export const Event = styled.div`
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  margin: 30px 100px 40px 100px;
+  width: 1000px;
+  margin: 50px 100px 40px 100px;
   padding: 30px 40px 60px 40px;
   border-radius: 10px;
 `;
@@ -52,9 +53,19 @@ export const EventName = styled(Text)`
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  font-size: 35px;
   background-color: white;
   line-height: 80px;
+  position: relative;
+  top: 10px;
+`;
+
+export const EventTitle = styled.div`
+  display: flex;
+  justify-content: center;
+  align-content: center;
+  position: relative;
+  top: 5px;
+  font-size: 35px;
 `;
 
 export const Line = styled('div')`
@@ -90,6 +101,8 @@ export const Qr = styled.div`
 `;
 
 export const QrBox = styled.div<{qrColor: string}>`
+  width: 400px;
+  height: 400px;
   margin-top: 10px;
   background-color: ${({qrColor}) => qrColor};
   border: 25px solid ${({qrColor}) => qrColor};

--- a/client/src/pages/QrCheckIn/MainQrCheckIn.tsx
+++ b/client/src/pages/QrCheckIn/MainQrCheckIn.tsx
@@ -30,9 +30,9 @@ const MainQrCheckIn = () => {
   };
 
   return (
-    <>
+    <Styled.Wrapper>
       <Header />
-      <Styled.Wrapper>
+      <Styled.InnerLayout>
         <Styled.Event>
           <Styled.Qr>
             <Styled.QrMessage messageColor={messageColor}>
@@ -58,8 +58,8 @@ const MainQrCheckIn = () => {
             </Styled.EventTime>
           </Styled.Qr>
         </Styled.Event>
-      </Styled.Wrapper>
-    </>
+      </Styled.InnerLayout>
+    </Styled.Wrapper>
   );
 };
 

--- a/client/src/pages/QrCheckIn/MainQrCheckIn.tsx
+++ b/client/src/pages/QrCheckIn/MainQrCheckIn.tsx
@@ -1,13 +1,10 @@
 import Header from '../../components/common/Header/Header';
 
-
 import React, {useState} from 'react';
 import * as Styled from './MainQrCheckIn.styles';
 import QrScan from '../../components/QrCheckIn/QrScan';
-import icon from '../../icon.png';
 import Logo from '../../components/common/Logo/Logo';
 import {useLocation} from 'react-router-dom';
-
 
 const MainQrCheckIn = () => {
   const [message, setMessage] = useState(
@@ -18,7 +15,9 @@ const MainQrCheckIn = () => {
 
   const location = useLocation();
   const eventId: string = location.state?.eventId || 'No Event ID';
-
+  const title: string = location.state?.title || 'No Title';
+  const startAt: string = location.state?.startAt || 'No Start Time';
+  const endAt: string = location.state?.endAt || 'No End Time';
 
   const handleScanResult = (
     newMessage: string,
@@ -30,55 +29,38 @@ const MainQrCheckIn = () => {
     setQrColor(newQrColor);
   };
 
-
-    return (
-          <>
-          <Header />
-            <Styled.Wrapper>
-                <Styled.Event>
-                    <Styled.EventContent>
-                        <Styled.Line></Styled.Line>
-                        <Styled.EventTime>
-                            <h3>2024.09.13 18:30</h3>
-                            <h3> ~ </h3>
-                            <h3>2024.09.13 20:00</h3>
-                        </Styled.EventTime>
-                        <Styled.Line></Styled.Line>
-                        <Styled.GroupBox>
-                            <p>참가 가능한 그룹</p>
-                            <p>WAP 2024</p>
-                        </Styled.GroupBox>
-                    </Styled.EventContent>
-                    <Styled.Qr>
-                        <Styled.EventName>
-                            <Logo src={'images/eventIcon.png'} alt={'logo3'} text={''} width={'50x'} height={'50px'}/>
-                            <h2>WAP 2024 2학기 시작발표</h2>
-                        </Styled.EventName>
-                        <Styled.QrBox qrColor={qrColor}>
-                            <QrScan onScanResult={handleScanResult} eventId={eventId}/>
-                        </Styled.QrBox>
-                        <Styled.QrMessage messageColor={messageColor}>
-                            <div>{message}</div>
-                        </Styled.QrMessage>
-                    </Styled.Qr>
-                    <Styled.EventContent>
-                        <Styled.Line></Styled.Line>
-                        <Styled.EventTime>
-                            <h3>2024.09.13 18:30</h3>
-                            <h3> ~ </h3>
-                            <h3>2024.09.13 20:00</h3>
-                        </Styled.EventTime>
-                        <Styled.Line></Styled.Line>
-                        <Styled.GroupBox>
-                            <p>참가 가능한 그룹</p>
-                            <p>WAP 2024</p>
-                        </Styled.GroupBox>
-                    </Styled.EventContent>
-                </Styled.Event>
-            </Styled.Wrapper>
-          </>
-    )
-}
-
+  return (
+    <>
+      <Header />
+      <Styled.Wrapper>
+        <Styled.Event>
+          <Styled.Qr>
+            <Styled.QrMessage messageColor={messageColor}>
+              <div>{message}</div>
+            </Styled.QrMessage>
+            <Styled.QrBox qrColor={qrColor}>
+              <QrScan onScanResult={handleScanResult} eventId={eventId} />
+            </Styled.QrBox>
+            <Styled.EventName>
+              <Logo
+                src={'images/eventIcon.png'}
+                alt={'logo3'}
+                text={''}
+                width={'50px'}
+                height={'50px'}
+              />
+              <h2>{title}</h2>
+            </Styled.EventName>
+            <Styled.EventTime>
+              <h3>{startAt}</h3>
+              <h3> ~ </h3>
+              <h3>{endAt}</h3>
+            </Styled.EventTime>
+          </Styled.Qr>
+        </Styled.Event>
+      </Styled.Wrapper>
+    </>
+  );
+};
 
 export default MainQrCheckIn;

--- a/client/src/pages/QrCheckIn/MainQrCheckIn.tsx
+++ b/client/src/pages/QrCheckIn/MainQrCheckIn.tsx
@@ -49,12 +49,10 @@ const MainQrCheckIn = () => {
                 width={'50px'}
                 height={'50px'}
               />
-              <h2>{title}</h2>
+              <Styled.EventTitle>{title}</Styled.EventTitle>
             </Styled.EventName>
             <Styled.EventTime>
-              <h3>{startAt}</h3>
-              <h3> ~ </h3>
-              <h3>{endAt}</h3>
+              <h3>{startAt + ' ~ ' + endAt}</h3>
             </Styled.EventTime>
           </Styled.Qr>
         </Styled.Event>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [x] 버그 수정 🐛
- [ ] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

### 변경 사항
- QR 체크인 화면에 이벤트 관련 데이터들을 useNavigator 에서 props 넘겨주었습니다.
```js
  const navigateToQrScanner = () => {
    navigate('/qrScan', {state: {eventId, title, startAt, endAt}});
  };
```

- QR 체크인 화면에서 QR 인식 화면을 정사각형으로 변경하고, 화면 중앙으로 이동시켰고, 사이드바들을 제거하였습니다. 
<img width="700" alt="image" src="https://github.com/user-attachments/assets/f94b6155-d2d5-4113-b72a-28f0628cd9c8">
<br><br>

- QR 체크인 임시로 에러 코드를 활용하여 체크인 현황을 보여주는 기능을 만들어놨습니다. 
```js
         if (res.data.message === 'OK') {
            onScanResult('정상적으로 참석되었습니다.', '#4E54F5', '#4E54F5');
          }
          setQrScanned(true);
        })
        .catch(error => {
          // 임시로 에러코드 활용하여 동작
          // 추후 백엔드 코드로 동작 예정
          if (error.response.status === 500) {
            onScanResult('이미 참석되었습니다.', '#F5C400', '#F5C400');
          } else {
            onScanResult('이벤트 해당그룹이 아닙니다.', '#FF7078', '#FF7078');
          }
```

- QR 체크인 후 체크인 결과를 보여주는 색깔을 1.5초로 늘렸습니다. https://github.com/pknu-wap/WABI-FE/pull/77/commits/f9d5569b64ca438843b67bad350a4696cf32939f
```js
      setTimeout(() => {
        setQrScanned(false);
        onScanResult(
          'QR CODE를 화면의 사각형 안에 맞춰주세요.',
          'black',
          'lightgray',
        );
        setNextScanned(prevKey => prevKey + 1);
      }, 1500);
```


- 체크인 현황 테이블에서 인원들의 소속 그룹이 안 보이는 에러가 받아오는 객체의 key 값 때문이어서 변경하였습니다. https://github.com/pknu-wap/WABI-FE/pull/77/commits/dcbd7051d6dbf7d28239684b6a85b92b5fa849a3


