### PR TITLE
[fix] : 이미 체크인한 인원 QR 인식 시 노란색 띄우기

### DIFF
--- a/client/src/components/GroupDetail/FileUploadModal/FileUploadModal.tsx
+++ b/client/src/components/GroupDetail/FileUploadModal/FileUploadModal.tsx
@@ -25,6 +25,7 @@ const FileUploadModal: React.FC<FileUploadModalProps> = ({
     const fileToUpload = file || new Blob();
     const fileFormData = new FormData();
     fileFormData.append('file', fileToUpload);
+    console.log(fileFormData);
     fileUpload(groupId, fileFormData);
   };
 

--- a/client/src/components/QrCheckIn/QrScan.tsx
+++ b/client/src/components/QrCheckIn/QrScan.tsx
@@ -42,18 +42,19 @@ const QrScan = ({onScanResult, eventId}: QrScanProps) => {
         .then(res => {
           if (res.data.message === 'OK') {
             onScanResult('정상적으로 참석되었습니다.', '#4E54F5', '#4E54F5');
-            setQrScanned(true);
           }
+          if (res.data.message === '이미 체크인 했습니다.') {
+            onScanResult('이미 참석되었습니다.', '#F5C400', '#F5C400');
+          }
+          setQrScanned(true);
         })
         .catch(error => {
           // 임시로 에러코드 활용하여 동작
           // 추후 백엔드 코드로 동작 예정
-          if (error.response.status === 500) {
-            onScanResult('이미 참석되었습니다.', '#F5C400', '#F5C400');
-          } else {
+          if (error) {
             onScanResult('이벤트 해당그룹이 아닙니다.', '#FF7078', '#FF7078');
+            setQrScanned(true);
           }
-          setQrScanned(true);
         });
 
       setTimeout(() => {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [x] 버그 수정 🐛
- [ ] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

### 변경 사항
- 600-1 코드를 받아오면 노란색을 뜨게 만들었습니다.

```js
      sendToServer(Student)
        .then(res => {
          if (res.data.message === 'OK') {
            onScanResult('정상적으로 참석되었습니다.', '#4E54F5', '#4E54F5');
          }
          if (res.data.message === '이미 체크인 했습니다.') {
            onScanResult('이미 참석되었습니다.', '#F5C400', '#F5C400');
          }
          setQrScanned(true);
        })
        .catch(error => {
          // 임시로 에러코드 활용하여 동작
          // 추후 백엔드 코드로 동작 예정
          if (error) {
            onScanResult('이벤트 해당그룹이 아닙니다.', '#FF7078', '#FF7078');
            setQrScanned(true);
          }
        });

```



